### PR TITLE
Updating version for Ehcache 2.x to 2.10.1

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -11,7 +11,7 @@ active_menu_id: ehc_mnu_download
 
 #### Ehcache 2.x
 
-> [Ehcache 2.10.0](http://d2zwv9pap9ylyd.cloudfront.net/ehcache-2.10.0-distribution.tar.gz)  .tar.gz
+> [Ehcache 2.10.1](http://d2zwv9pap9ylyd.cloudfront.net/ehcache-2.10.1-distribution.tar.gz)  .tar.gz
 
 
 For more information on this release, see the [release notes](http://www.terracotta.org/confluence/display/release/Home).


### PR DESCRIPTION
Please merge to master to update the link for downloading ehcache 2.10.1